### PR TITLE
#42 | Added new sbb styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# 0.1.6
+
+### Features
+* **theme:** introduce SBBTypography and new text styles
+
 # 0.1.5
 
 ### Features

--- a/compose-mds/src/main/java/ch/sbb/compose_mds/theme/SBBTheme.kt
+++ b/compose-mds/src/main/java/ch/sbb/compose_mds/theme/SBBTheme.kt
@@ -42,7 +42,18 @@ object SBBTheme {
         @Composable
         get() = LocalThemeContext.current.colorScheme(isDarkMode)
 
+    @Deprecated("Use materialTypography instead", ReplaceWith("SBBTheme.materialTypography"))
     val typography: Typography
+        @ReadOnlyComposable
+        @Composable
+        get() = LocalSBBTypography.current.materialTypography //LocalSBBTypography.current
+
+    val materialTypography: Typography
+        @ReadOnlyComposable
+        @Composable
+        get() = LocalSBBTypography.current.materialTypography
+
+    val sbbTypography: SBBTypography
         @ReadOnlyComposable
         @Composable
         get() = LocalSBBTypography.current
@@ -69,11 +80,11 @@ fun SBBTheme(
     CompositionLocalProvider(
         LocalThemeContext provides themeContext,
         LocalSBBIsDarkMode provides darkTheme,
-        LocalSBBTypography provides SBBTypography.default(fontFamily = fontFamily),
+        LocalSBBTypography provides SBBTypography(fontFamily = fontFamily),
     ) {
         MaterialTheme(
             colorScheme = SBBTheme.colorScheme,
-            typography = SBBTheme.typography,
+            typography = SBBTheme.materialTypography,
             content = { if (includeSurface) Surface { content() } else content() },
         )
     }

--- a/compose-mds/src/main/java/ch/sbb/compose_mds/theme/SBBTypography.kt
+++ b/compose-mds/src/main/java/ch/sbb/compose_mds/theme/SBBTypography.kt
@@ -1,121 +1,242 @@
 package ch.sbb.compose_mds.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-internal val LocalSBBTypography = staticCompositionLocalOf<Typography> { SBBTypography.default() }
+internal val LocalSBBTypography = staticCompositionLocalOf<SBBTypography> { SBBTypography() }
 
-object SBBTypography {
-    fun default(fontFamily: FontFamily? = null): Typography =
+// Font sizes
+val xxLargeFontSize = 30.sp
+val xLargeFontSize = 24.sp
+val largeFontSize = 18.sp
+val mediumFontSize = 16.sp
+val smallFontSize = 14.sp
+val xSmallFontSize = 12.sp
+val xxSmallFontSize = 10.sp
+
+// Font heights
+val xxLargeFontHeight = 32.sp
+val xLargeFontHeight = 32.sp
+val largeFontHeight = 24.sp
+val mediumFontHeight = 20.sp
+val smallFontHeight = 20.sp
+val xSmallFontHeight = 16.sp
+val xxSmallFontHeight = 12.sp
+
+internal interface SBBTypographyTokens {
+    val XXLargeLight: TextStyle
+    val XXLargeBold: TextStyle
+    val XLargeLight: TextStyle
+    val XLargeBold: TextStyle
+    val largeLight: TextStyle
+    val largeBold: TextStyle
+    val mediumLight: TextStyle
+    val mediumBold: TextStyle
+    val smallLight: TextStyle
+    val smallBold: TextStyle
+    val XSmallLight: TextStyle
+    val XSmallBold: TextStyle
+    val XXSmallLight: TextStyle
+    val XXSmallBold: TextStyle
+    val helpersLabel: TextStyle
+}
+
+@Stable
+internal fun configSBBTypographyTokens(fontFamily: FontFamily? = null): SBBTypographyTokens =
+    object : SBBTypographyTokens {
+        override val XXLargeLight: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = xxLargeFontSize,
+                    lineHeight = xxLargeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+        override val XXLargeBold: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = xxLargeFontSize,
+                    lineHeight = xxLargeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val XLargeLight: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = xLargeFontSize,
+                    lineHeight = xLargeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+        override val XLargeBold: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = xLargeFontSize,
+                    lineHeight = xLargeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val largeLight: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = largeFontSize,
+                    lineHeight = largeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+
+        override val largeBold: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = largeFontSize,
+                    lineHeight = largeFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val mediumLight: TextStyle
+            get() =
+                TextStyle(
+                    fontFamily = fontFamily,
+                    fontSize = mediumFontSize,
+                    lineHeight = mediumFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+        override val mediumBold: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = mediumFontSize,
+                    lineHeight = mediumFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val smallLight: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = smallFontSize,
+                    lineHeight = smallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+        override val smallBold: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = smallFontSize,
+                    lineHeight = smallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val XSmallLight: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = xSmallFontSize,
+                    lineHeight = xSmallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Light,
+                )
+        override val XSmallBold: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = xSmallFontSize,
+                    lineHeight = xSmallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val XXSmallLight: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = xxSmallFontSize,
+                    lineHeight = xxSmallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Normal,
+                )
+        override val XXSmallBold: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = xxSmallFontSize,
+                    lineHeight = xxSmallFontHeight,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Bold,
+                )
+        override val helpersLabel: TextStyle
+            get() =
+                TextStyle(
+                    fontSize = 10.sp,
+                    lineHeight = 12.sp,
+                    fontStyle = FontStyle.Normal,
+                    fontWeight = FontWeight.Normal,
+                )
+    }
+
+@Immutable
+class SBBTypography(
+    val fontFamily: FontFamily? = null,
+) : SBBTypographyTokens by configSBBTypographyTokens(fontFamily) {
+    val materialTypography: Typography =
         Typography(
-            displayLarge =
+            displayLarge = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W300,
                     fontSize = 30.sp,
                     lineHeight = 38.sp,
                 ),
-            displayMedium =
+            displayMedium = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W300,
                     fontSize = 28.sp,
                     lineHeight = 36.sp,
                 ),
-            displaySmall =
+            displaySmall = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W300,
                     fontSize = 26.sp,
                     lineHeight = 34.sp,
                 ),
-            headlineLarge =
+            headlineLarge = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W700,
                     fontSize = 18.sp,
                     lineHeight = 24.sp,
                 ),
-            headlineMedium =
+            headlineMedium = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W700,
                     fontSize = 16.sp,
                     lineHeight = 22.sp,
                 ),
-            headlineSmall =
+            headlineSmall = // TODO needs mapping
                 TextStyle(
                     fontFamily = fontFamily,
                     fontWeight = FontWeight.W700,
                     fontSize = 14.sp,
                     lineHeight = 20.sp,
                 ),
-            titleLarge =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 18.sp,
-                    lineHeight = 24.sp,
-                ),
-            titleMedium =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 16.sp,
-                    lineHeight = 22.sp,
-                ),
-            titleSmall =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                ),
-            bodyLarge =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 16.sp,
-                    lineHeight = 24.sp,
-                ),
-            bodyMedium =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                ),
-            bodySmall =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 12.sp,
-                    lineHeight = 18.sp,
-                ),
-            labelLarge =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                ),
-            labelMedium =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 12.sp,
-                    lineHeight = 16.sp,
-                ),
-            labelSmall =
-                TextStyle(
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 10.sp,
-                    lineHeight = 14.sp,
-                ),
+            titleLarge = largeBold,
+            titleMedium = mediumBold,
+            titleSmall = smallBold,
+            bodyLarge = largeLight,
+            bodyMedium = mediumLight,
+            bodySmall = smallLight,
+            labelLarge = largeLight,
+            labelMedium = mediumLight,
+            labelSmall = smallLight,
         )
 }

--- a/example/src/main/java/ch/sbb/compose_mds/example/pages/TypographyPage.kt
+++ b/example/src/main/java/ch/sbb/compose_mds/example/pages/TypographyPage.kt
@@ -18,47 +18,80 @@ import ch.sbb.compose_mds.beta.ExperimentalSBBComponent
 import ch.sbb.compose_mds.beta.container.SBBGroup
 import ch.sbb.compose_mds.beta.list.SBBListHeader
 import ch.sbb.compose_mds.theme.SBBConst
+import ch.sbb.compose_mds.theme.SBBTypography
 
 private const val DEFAULT_TEXT = "The quick brown fox jumps over the lazy dog"
 
 @Composable
 fun TypographyPage() {
     Column(
-        modifier = Modifier
-            .verticalScroll(rememberScrollState())
-            .padding(vertical = SBBConst.HALF_PADDING)
+        modifier =
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = SBBConst.HALF_PADDING),
     ) {
-        TextStylePreview(name = "Display Large", MaterialTheme.typography.displayLarge)
-        TextStylePreview(name = "Display Medium", MaterialTheme.typography.displayMedium)
-        TextStylePreview(name = "Display Small", MaterialTheme.typography.displaySmall)
-
-        TextStylePreview(name = "Headline Large", MaterialTheme.typography.headlineLarge)
-        TextStylePreview(name = "Headline Medium", MaterialTheme.typography.headlineMedium)
-        TextStylePreview(name = "Headline Small", MaterialTheme.typography.headlineSmall)
-
-        TextStylePreview(name = "Title Large", MaterialTheme.typography.titleLarge)
-        TextStylePreview(name = "Title Medium", MaterialTheme.typography.titleMedium)
-        TextStylePreview(name = "Title Small", MaterialTheme.typography.titleSmall)
-
-        TextStylePreview(name = "Body Large", MaterialTheme.typography.bodyLarge)
-        TextStylePreview(name = "Body Medium", MaterialTheme.typography.bodyMedium)
-        TextStylePreview(name = "Body Small", MaterialTheme.typography.bodySmall)
-
-        TextStylePreview(name = "Label Large", MaterialTheme.typography.labelLarge)
-        TextStylePreview(name = "Label Medium", MaterialTheme.typography.labelMedium)
-        TextStylePreview(name = "Label Small", MaterialTheme.typography.labelSmall)
+        MaterialTypography()
+        SBBTypographySection()
     }
+}
+
+@Composable
+private fun MaterialTypography() {
+    TextStylePreview(name = "Display Large", MaterialTheme.typography.displayLarge)
+    TextStylePreview(name = "Display Medium", MaterialTheme.typography.displayMedium)
+    TextStylePreview(name = "Display Small", MaterialTheme.typography.displaySmall)
+
+    TextStylePreview(name = "Headline Large", MaterialTheme.typography.headlineLarge)
+    TextStylePreview(name = "Headline Medium", MaterialTheme.typography.headlineMedium)
+    TextStylePreview(name = "Headline Small", MaterialTheme.typography.headlineSmall)
+
+    TextStylePreview(name = "Title Large", MaterialTheme.typography.titleLarge)
+    TextStylePreview(name = "Title Medium", MaterialTheme.typography.titleMedium)
+    TextStylePreview(name = "Title Small", MaterialTheme.typography.titleSmall)
+
+    TextStylePreview(name = "Body Large", MaterialTheme.typography.bodyLarge)
+    TextStylePreview(name = "Body Medium", MaterialTheme.typography.bodyMedium)
+    TextStylePreview(name = "Body Small", MaterialTheme.typography.bodySmall)
+
+    TextStylePreview(name = "Label Large", MaterialTheme.typography.labelLarge)
+    TextStylePreview(name = "Label Medium", MaterialTheme.typography.labelMedium)
+    TextStylePreview(name = "Label Small", MaterialTheme.typography.labelSmall)
+}
+
+@Composable
+private fun SBBTypographySection() {
+    TextStylePreview(name = "XXLargeLight", SBBTheme.sbbTypography.XXLargeLight)
+    TextStylePreview(name = "XXLargeBold", SBBTheme.sbbTypography.XXLargeBold)
+    TextStylePreview(name = "XLargeLight", SBBTheme.sbbTypography.XLargeLight)
+    TextStylePreview(name = "XLargeBold", SBBTheme.sbbTypography.XLargeBold)
+    TextStylePreview(name = "LargeLight", SBBTheme.sbbTypography.largeLight)
+    TextStylePreview(name = "LargeBold", SBBTheme.sbbTypography.largeBold)
+
+    TextStylePreview(name = "MediumLight", SBBTheme.sbbTypography.mediumLight)
+    TextStylePreview(name = "MediumBold", SBBTheme.sbbTypography.mediumBold)
+
+    TextStylePreview(name = "SmallLight", SBBTheme.sbbTypography.smallLight)
+    TextStylePreview(name = "SmallBold", SBBTheme.sbbTypography.smallBold)
+    TextStylePreview(name = "XSmallLight", SBBTheme.sbbTypography.XSmallLight)
+    TextStylePreview(name = "XSmallBold", SBBTheme.sbbTypography.XSmallBold)
+    TextStylePreview(name = "XXSmallLight", SBBTheme.sbbTypography.XXSmallLight)
+    TextStylePreview(name = "XXSmallBold", SBBTheme.sbbTypography.XXSmallBold)
+
+
 }
 
 @OptIn(ExperimentalSBBComponent::class)
 @Composable
-private fun TextStylePreview(name: String, style: TextStyle) {
+private fun TextStylePreview(
+    name: String,
+    style: TextStyle,
+) {
     SBBListHeader(text = name)
     SBBGroup(modifier = Modifier.padding(horizontal = SBBConst.DEFAULT_HORIZONTAL_PADDING)) {
         Text(
             text = DEFAULT_TEXT,
             style = style,
-            modifier = Modifier.padding(all = SBBConst.DEFAULT_PADDING)
+            modifier = Modifier.padding(all = SBBConst.DEFAULT_PADDING),
         )
         HorizontalDivider()
         TextStyleInfos(style = style)
@@ -70,10 +103,9 @@ private fun TextStyleInfos(style: TextStyle) {
     Text(
         text = "fontWeight: ${style.fontWeight}\n" + "fontSize: ${style.fontSize}\n" + "lineHeight: ${style.lineHeight}",
         style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(all = SBBConst.DEFAULT_PADDING)
+        modifier = Modifier.padding(all = SBBConst.DEFAULT_PADDING),
     )
 }
-
 
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)


### PR DESCRIPTION
Feat(theme): Introduce SBBTypography and new text styles

  Summary

  This pull request introduces a new SBBTypography class to provide SBB-specific text styles, decoupling the SBB typography from the Material Design typography
  system. This change allows for a more granular and SBB-specific typography system while maintaining backward compatibility with the existing Material Typography.

  Changes


   * New `SBBTypography` class: A new SBBTypography class has been created to hold all SBB-specific text styles. This class now serves as the single source of truth
     for SBB typography.
   * Decoupling from Material Design: The SBB typography is now decoupled from the Material Design typography system. The SBBTheme now provides both sbbTypography
     (for SBB-specific styles) and materialTypography (for the Material theme).
   * Backwards Compatibility: The new SBB text styles are mapped to the Material Typography to ensure backward compatibility. The old typography property in SBBTheme
     is now deprecated.
   * Example App Update: The TypographyPage in the example app has been updated to display both the SBB and Material text styles, providing a clear overview of the
     new typography system.